### PR TITLE
Modified LGPL for uwin32widgetsetdark.pas

### DIFF
--- a/src/platform/win/uwin32widgetsetdark.pas
+++ b/src/platform/win/uwin32widgetsetdark.pas
@@ -8,7 +8,19 @@
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+  version 2.1 of the License, or (at your option) any later version
+  with the following modification:
+
+  As a special exception, the copyright holders of this library give you
+  permission to link this library with independent modules to produce an
+  executable, regardless of the license terms of these independent modules,and
+  to copy and distribute the resulting executable under terms of your choice,
+  provided that you also meet, for each linked independent module, the terms
+  and conditions of the license of that module. An independent module is a
+  module which is not derived from or based on this library. If you modify
+  this library, you may extend this exception to your version of the library,
+  but you are not obligated to do so. If you do not wish to do so, delete this
+  exception statement from your version.
 
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -1878,4 +1890,5 @@ initialization
   Initialize;
 
 end.
+
 


### PR DESCRIPTION
The copyright holder has generously approved the addition of a static linking exception to the license (as in the LCL).